### PR TITLE
Set ommited properties in req.body to empty empty array by default

### DIFF
--- a/src/modules/claims/claims.services.js
+++ b/src/modules/claims/claims.services.js
@@ -64,9 +64,9 @@ export default class ClaimsService extends AppService {
 
   async handleBulkClaimProcessing() {
     const {
-      remove: arrOfClaimIds,
-      update: arrOfUpdates,
-      create: arrOfNewClaims,
+      remove: arrOfClaimIds = [],
+      update: arrOfUpdates = [],
+      create: arrOfNewClaims = [],
       referalCode,
     } = this.body;
 


### PR DESCRIPTION
- Set ommited properties in req.body to empty empty array by default