### PR TITLE
Set ommited properties in req.body to empty empty array by default

### DIFF
--- a/src/modules/claims/claims.routes.js
+++ b/src/modules/claims/claims.routes.js
@@ -25,7 +25,7 @@ router.get(
 
 router.patch(
   '/',
-  AuthMiddleware.authorize([HCP, TIER_1_MEDICAL, TIER_2_MEDICAL]),
+  AuthMiddleware.authorize([MD, HCP, TIER_1_MEDICAL, TIER_2_MEDICAL]),
   ClaimsMiddleware.validateBulkClaimProcessing,
   ClaimsController.processBulkClaims
 );

--- a/src/modules/claims/claims.services.js
+++ b/src/modules/claims/claims.services.js
@@ -64,9 +64,9 @@ export default class ClaimsService extends AppService {
 
   async handleBulkClaimProcessing() {
     const {
-      remove: arrOfClaimIds,
-      update: arrOfUpdates,
-      create: arrOfNewClaims,
+      remove: arrOfClaimIds = [],
+      update: arrOfUpdates = [],
+      create: arrOfNewClaims = [],
       referalCode,
     } = this.body;
 


### PR DESCRIPTION
- Set ommited properties in req.body to empty empty array by default